### PR TITLE
fix(gfi): replace webhook with discord bot to manage gfi messages

### DIFF
--- a/.github/workflows/discord-gfi.yml
+++ b/.github/workflows/discord-gfi.yml
@@ -1,6 +1,7 @@
 name: Update good-first-issues list
 
 on:
+  workflow_dispatch:
   # Re-build when labels or state change
   issues:
     types: [opened, reopened, edited, labeled, unlabeled, closed]
@@ -13,40 +14,74 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Build embed text (top-20)
-        id: make
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo  = context.repo.repo;
-            const q = `repo:${owner}/${repo} label:"good first issue" state:open`;
-            const { data } = await github.rest.search.issuesAndPullRequests({ q, per_page: 20, sort: "created", order: "asc" });
+    # ---------- Build the embed ----------
+    - name: Build embed JSON (top-20)
+      id: build
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { owner, repo } = context.repo;
 
-            const lines = data.items.map(i => `• [#${i.number} ${i.title}](${i.html_url}) — _${i.user.login}_`);
-            const embed = {
-              embeds: [{
-                title: "🆕 RecentGood-first-issues",
-                url: `https://github.com/${owner}/${repo}/issues?q=label%3A%22good+first+issue%22+is%3Aopen`,
-                description: lines.join("\n"),
-                color: 504575,
-                footer: { text: "Last updated" },
-                timestamp: new Date().toISOString()
-              }]
-            };
-            return Buffer.from(JSON.stringify(embed)).toString('base64');
+          // pull first 20 open issues with that label
+          const { data: issues } = await github.rest.issues.listForRepo({
+            owner, repo,
+            state: 'open',
+            labels: 'good first issue',
+            per_page: 20
+          });
 
-      - name: Push embed to Discord (replace old msg)
-        env:
-          HOOK: ${{ secrets.DISCORD_GFI_WEBHOOK }}
-          PAYLOAD_B64: ${{ steps.make.outputs.result }}
-        run: |
-          set -e
-          payload="$(echo "$PAYLOAD_B64" | base64 -d)"
+          // map to bullets: show other labels comma-separated after a hyphen
+          const lines = issues.map(i => {
+            const extras = i.labels
+              .filter(l => l.name !== 'good first issue')
+              .map(l => `\`${l.name}\``);
+            const base = `• [#${i.number}](${i.html_url}) ${i.title}`;
+            return extras.length
+              ? `${base} - ${extras.join(', ')}`
+              : base;
+          });
 
-          # Get last 50 messages; find one authored by this webhook
-          last=$(curl -s "$HOOK/messages?limit=50" | jq -r 'map(select(.author.bot==true))[0].id // empty')
-          [[ -n "$last" ]] && curl -s -X DELETE "$HOOK/messages/$last" >/dev/null
+          const embed = {
+            embeds: [{
+              title: '🆕 Good-first-issues',
+              url:   `https://github.com/${owner}/${repo}/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22`,
+              description: lines.join('\n'),
+              color: 504575,
+              timestamp: new Date().toISOString()
+            }]
+          };
 
-          # Replace the old message with the new one
-          curl -s -H "Content-Type: application/json" -d "$payload" "$HOOK" >/dev/null
+          // expose as a base-64 string
+          core.setOutput(
+            'b64',
+            Buffer.from(JSON.stringify(embed)).toString('base64')
+          );
+
+    # ---------- Post via bot ----------
+    - name: Push embed (replace old message)
+      env:
+        BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+        BOT_ID:    ${{ secrets.DISCORD_BOT_ID }}
+        CHANNEL_ID: ${{ secrets.DISCORD_CHANNEL_ID_GOOD_FIRST_ISSUES }}
+        PAYLOAD_B64: ${{ steps.build.outputs.b64 }}
+      run: |
+        set -euo pipefail
+        payload=$(printf '%s' "$PAYLOAD_B64" | base64 --decode)
+        AUTH="Authorization: Bot ${BOT_TOKEN}"
+
+        # 1) delete last bot message (if any)
+        last=$(curl -sf -H "$AUTH" \
+                "https://discord.com/api/channels/${CHANNEL_ID}/messages?limit=50" |
+              jq -r --arg BID "$BOT_ID" '
+                    map(select(.author.id==$BID))[0].id // empty')
+        if [ -n "$last" ]; then
+          curl -s -X DELETE -H "$AUTH" \
+              "https://discord.com/api/channels/${CHANNEL_ID}/messages/${last}" >/dev/null
+        fi
+
+        # 2) post fresh embed
+        curl -s -H "$AUTH" -H "Content-Type: application/json" \
+            -d "$payload" \
+            "https://discord.com/api/channels/${CHANNEL_ID}/messages" >/dev/null
+
+


### PR DESCRIPTION
## Description
Publishes the list of good first issues on Discord using a bot instead of a webhook. This allows the previously posted message to be deleted, keeping the channel clean. 
Github actions are currently failing as the webhook tries to perform forbidden actions (deleting the previous message in the channel) 

## Type of Change

- [x] Fix 

## Additional Notes

The `DISCORD_BOT_TOKEN`, `DISCORD_BOT_ID`, `DISCORD_CHANNEL_ID_GOOD_FIRST_ISSUES` secrets need to be configured in the repository settings