### PR TITLE
chore(litellm): add support for all llm providers supported by litellm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Skyflo.ai is your AI-powered companion for cloud native operations, enabling sea
 Skyflo.ai offers flexible deployment options, accommodating both production and local Kubernetes environments:
 
 ```bash
-export OPENAI_API_KEY='your-openai-api-key'
 curl -sL https://raw.githubusercontent.com/skyflo-ai/skyflo/main/deployment/install.sh -o install.sh && chmod +x install.sh && ./install.sh
 ```
 

--- a/deployment/install.sh
+++ b/deployment/install.sh
@@ -341,7 +341,7 @@ For production setup and more information, visit:
         # Prompt for LLM configuration
         print_colored "yellow" "LLM Configuration:"
         while true; do
-            read -p "Enter LLM_MODEL (format: provider/model_name, e.g., openai/gpt-4o, groq/meta-llama/Llama-3-70b-chat, ollama/llama3): " LLM_MODEL
+            read -p "Enter LLM_MODEL (format: provider/model_name, e.g., openai/gpt-4o, groq/meta-llama/llama-4-scout-17b-16e-instruct, gemini/gemini-2.5-flash-preview-04-17, ollama/llama3.1:8b): " LLM_MODEL
             if [ -z "$LLM_MODEL" ]; then
                 print_colored "red" "LLM_MODEL cannot be empty."
             elif [[ ! "$LLM_MODEL" == *"/"* ]]; then

--- a/deployment/install.sh
+++ b/deployment/install.sh
@@ -218,9 +218,27 @@ case $choice in  # Modified case statement without bash-specific lowercase conve
             "alephalpha")
                 API_KEY_VAR_NAME="ALEPHALPHA_API_KEY"
                 ;;
+            "featherless")
+                API_KEY_VAR_NAME="FEATHERLESS_AI_API_KEY"
+                ;;
+            "baseten")
+                API_KEY_VAR_NAME="BASETEN_API_KEY"
+                ;;
+            "sambanova")
+                API_KEY_VAR_NAME="SAMBANOVA_API_KEY"
+                ;;
+            "xai")
+                API_KEY_VAR_NAME="XAI_API_KEY"
+                ;;
+            "volcengine")
+                API_KEY_VAR_NAME="VOLCENGINE_API_KEY"
+                ;;
+            "predibase")
+                API_KEY_VAR_NAME="PREDIBASE_API_KEY"
+                ;;
             *)
                 # Default format: PROVIDER_API_KEY
-        API_KEY_VAR_NAME="${LLM_PROVIDER_UPPER}_API_KEY"
+                API_KEY_VAR_NAME="${LLM_PROVIDER_UPPER}_API_KEY"
                 ;;
         esac
 
@@ -383,9 +401,27 @@ For production setup and more information, visit:
             "alephalpha")
                 API_KEY_VAR_NAME="ALEPHALPHA_API_KEY"
                 ;;
+            "featherless")
+                API_KEY_VAR_NAME="FEATHERLESS_AI_API_KEY"
+                ;;
+            "baseten")
+                API_KEY_VAR_NAME="BASETEN_API_KEY"
+                ;;
+            "sambanova")
+                API_KEY_VAR_NAME="SAMBANOVA_API_KEY"
+                ;;
+            "xai")
+                API_KEY_VAR_NAME="XAI_API_KEY"
+                ;;
+            "volcengine")
+                API_KEY_VAR_NAME="VOLCENGINE_API_KEY"
+                ;;
+            "predibase")
+                API_KEY_VAR_NAME="PREDIBASE_API_KEY"
+                ;;
             *)
                 # Default format: PROVIDER_API_KEY
-        API_KEY_VAR_NAME="${LLM_PROVIDER_UPPER}_API_KEY"
+                API_KEY_VAR_NAME="${LLM_PROVIDER_UPPER}_API_KEY"
                 ;;
         esac
 

--- a/deployment/install.yaml
+++ b/deployment/install.yaml
@@ -11,16 +11,17 @@ metadata:
   namespace: skyflo-ai
 type: Opaque
 stringData:
-  # Core cloud LLMs
+  # Major Cloud LLM Providers
   openai-api-key: ${OPENAI_API_KEY}
   anthropic-api-key: ${ANTHROPIC_API_KEY}
   azure-api-key: ${AZURE_API_KEY}
   gemini-api-key: ${GEMINI_API_KEY}
   cohere-api-key: ${COHERE_API_KEY}
   mistral-api-key: ${MISTRAL_API_KEY}
+
+  # Alternative LLM Providers
   groq-api-key: ${GROQ_API_KEY}
   anyscale-api-key: ${ANYSCALE_API_KEY}
-  openrouter-api-key: ${OPENROUTER_API_KEY}
   perplexity-api-key: ${PERPLEXITYAI_API_KEY}
   fireworks-ai-api-key: ${FIREWORKS_AI_API_KEY}
   togetherai-api-key: ${TOGETHERAI_API_KEY}
@@ -28,34 +29,31 @@ stringData:
   ai21-api-key: ${AI21_API_KEY}
   nlp-cloud-api-key: ${NLP_CLOUD_API_KEY}
   replicate-api-key: ${REPLICATE_API_KEY}
-  huggingface-token: ${HF_TOKEN}
-
-  # AWS / specialized back-ends
-  bedrock-aws-access-key-id: ${AWS_ACCESS_KEY_ID}
-  bedrock-aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
-  bedrock-aws-region-name: ${AWS_REGION_NAME}
-
-  # Other providers
-  databricks-token: ${DATABRICKS_TOKEN}
-  clarifai-pat: ${CLARIFAI_PAT}
-  voyage-api-key: ${VOYAGE_API_KEY}
   jina-ai-api-key: ${JINAAI_API_KEY}
   alephalpha-api-key: ${ALEPHALPHA_API_KEY}
+  voyage-api-key: ${VOYAGE_API_KEY}
+
+  # Enterprise & Research Providers
+  databricks-token: ${DATABRICKS_TOKEN}
+  clarifai-pat: ${CLARIFAI_PAT}
   baseten-api-key: ${BASETEN_API_KEY}
   sambanova-api-key: ${SAMBANOVA_API_KEY}
-  snowflake-api-key: ${SNOWFLAKE_API_KEY}
-  featherless-api-key: ${FEATHERLESS_API_KEY}
-
-  # Local providers
-  ollama-api-key: ${OLLAMA_API_KEY}
-
-  # Audio/speech and misc endpoints
-  deepgram-api-key: ${DEEPGRAM_API_KEY}
+  featherless-api-key: ${FEATHERLESS_AI_API_KEY}
   ibm-watsonx-api-key: ${IBM_API_KEY}
   predibase-api-key: ${PREDIBASE_API_KEY}
   nvidia-nim-api-key: ${NVIDIA_NGC_API_KEY}
   xai-api-key: ${XAI_API_KEY}
   volcengine-api-key: ${VOLCENGINE_API_KEY}
+
+  # Infrastructure & Routing
+  openrouter-api-key: ${OPENROUTER_API_KEY}
+  huggingface-token: ${HF_TOKEN}
+  bedrock-aws-access-key-id: ${AWS_ACCESS_KEY_ID}
+  bedrock-aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  bedrock-aws-region-name: ${AWS_REGION_NAME}
+
+  # Self-hosted / On-premise
+  ollama-api-key: ${OLLAMA_API_KEY}
 
   # System configuration
   llm-host: ${LLM_HOST}
@@ -850,13 +848,7 @@ spec:
               name: skyflo-secrets
               key: sambanova-api-key
               optional: true
-        - name: SNOWFLAKE_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: skyflo-secrets
-              key: snowflake-api-key
-              optional: true
-        - name: FEATHERLESS_API_KEY
+        - name: FEATHERLESS_AI_API_KEY
           valueFrom:
             secretKeyRef:
               name: skyflo-secrets
@@ -867,12 +859,6 @@ spec:
             secretKeyRef:
               name: skyflo-secrets
               key: ollama-api-key
-              optional: true
-        - name: DEEPGRAM_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: skyflo-secrets
-              key: deepgram-api-key
               optional: true
         - name: IBM_API_KEY
           valueFrom:

--- a/deployment/install.yaml
+++ b/deployment/install.yaml
@@ -15,6 +15,7 @@ stringData:
   anthropic-api-key: ${ANTHROPIC_API_KEY}
   groq-api-key: ${GROQ_API_KEY}
   ollama-api-key: ${OLLAMA_API_KEY}
+  gemini-api-key: ${GEMINI_API_KEY}
   llm-host: ${LLM_HOST}
   llm-model: ${LLM_MODEL}
   jwt-secret: ${JWT_SECRET}
@@ -668,6 +669,12 @@ spec:
             secretKeyRef:
               name: skyflo-secrets
               key: ollama-api-key
+              optional: true
+        - name: GEMINI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: gemini-api-key
               optional: true
         - name: LLM_HOST
           valueFrom:

--- a/deployment/install.yaml
+++ b/deployment/install.yaml
@@ -11,11 +11,53 @@ metadata:
   namespace: skyflo-ai
 type: Opaque
 stringData:
+  # Core cloud LLMs
   openai-api-key: ${OPENAI_API_KEY}
   anthropic-api-key: ${ANTHROPIC_API_KEY}
-  groq-api-key: ${GROQ_API_KEY}
-  ollama-api-key: ${OLLAMA_API_KEY}
+  azure-api-key: ${AZURE_API_KEY}
   gemini-api-key: ${GEMINI_API_KEY}
+  cohere-api-key: ${COHERE_API_KEY}
+  mistral-api-key: ${MISTRAL_API_KEY}
+  groq-api-key: ${GROQ_API_KEY}
+  anyscale-api-key: ${ANYSCALE_API_KEY}
+  openrouter-api-key: ${OPENROUTER_API_KEY}
+  perplexity-api-key: ${PERPLEXITYAI_API_KEY}
+  fireworks-ai-api-key: ${FIREWORKS_AI_API_KEY}
+  togetherai-api-key: ${TOGETHERAI_API_KEY}
+  deepinfra-api-key: ${DEEPINFRA_API_KEY}
+  ai21-api-key: ${AI21_API_KEY}
+  nlp-cloud-api-key: ${NLP_CLOUD_API_KEY}
+  replicate-api-key: ${REPLICATE_API_KEY}
+  huggingface-token: ${HF_TOKEN}
+
+  # AWS / specialized back-ends
+  bedrock-aws-access-key-id: ${AWS_ACCESS_KEY_ID}
+  bedrock-aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  bedrock-aws-region-name: ${AWS_REGION_NAME}
+
+  # Other providers
+  databricks-token: ${DATABRICKS_TOKEN}
+  clarifai-pat: ${CLARIFAI_PAT}
+  voyage-api-key: ${VOYAGE_API_KEY}
+  jina-ai-api-key: ${JINAAI_API_KEY}
+  alephalpha-api-key: ${ALEPHALPHA_API_KEY}
+  baseten-api-key: ${BASETEN_API_KEY}
+  sambanova-api-key: ${SAMBANOVA_API_KEY}
+  snowflake-api-key: ${SNOWFLAKE_API_KEY}
+  featherless-api-key: ${FEATHERLESS_API_KEY}
+
+  # Local providers
+  ollama-api-key: ${OLLAMA_API_KEY}
+
+  # Audio/speech and misc endpoints
+  deepgram-api-key: ${DEEPGRAM_API_KEY}
+  ibm-watsonx-api-key: ${IBM_API_KEY}
+  predibase-api-key: ${PREDIBASE_API_KEY}
+  nvidia-nim-api-key: ${NVIDIA_NGC_API_KEY}
+  xai-api-key: ${XAI_API_KEY}
+  volcengine-api-key: ${VOLCENGINE_API_KEY}
+
+  # System configuration
   llm-host: ${LLM_HOST}
   llm-model: ${LLM_MODEL}
   jwt-secret: ${JWT_SECRET}
@@ -658,11 +700,167 @@ spec:
               name: skyflo-secrets
               key: anthropic-api-key
               optional: true
+        - name: AZURE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: azure-api-key
+              optional: true
+        - name: GEMINI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: gemini-api-key
+              optional: true
+        - name: COHERE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: cohere-api-key
+              optional: true
+        - name: MISTRAL_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: mistral-api-key
+              optional: true
         - name: GROQ_API_KEY
           valueFrom:
             secretKeyRef:
               name: skyflo-secrets
               key: groq-api-key
+              optional: true
+        - name: ANYSCALE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: anyscale-api-key
+              optional: true
+        - name: OPENROUTER_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: openrouter-api-key
+              optional: true
+        - name: PERPLEXITYAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: perplexity-api-key
+              optional: true
+        - name: FIREWORKS_AI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: fireworks-ai-api-key
+              optional: true
+        - name: TOGETHERAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: togetherai-api-key
+              optional: true
+        - name: DEEPINFRA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: deepinfra-api-key
+              optional: true
+        - name: AI21_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: ai21-api-key
+              optional: true
+        - name: NLP_CLOUD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: nlp-cloud-api-key
+              optional: true
+        - name: REPLICATE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: replicate-api-key
+              optional: true
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: huggingface-token
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: bedrock-aws-access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: bedrock-aws-secret-access-key
+              optional: true
+        - name: AWS_REGION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: bedrock-aws-region-name
+              optional: true
+        - name: DATABRICKS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: databricks-token
+              optional: true
+        - name: CLARIFAI_PAT
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: clarifai-pat
+              optional: true
+        - name: VOYAGE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: voyage-api-key
+              optional: true
+        - name: JINAAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: jina-ai-api-key
+              optional: true
+        - name: ALEPHALPHA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: alephalpha-api-key
+              optional: true
+        - name: BASETEN_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: baseten-api-key
+              optional: true
+        - name: SAMBANOVA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: sambanova-api-key
+              optional: true
+        - name: SNOWFLAKE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: snowflake-api-key
+              optional: true
+        - name: FEATHERLESS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: featherless-api-key
               optional: true
         - name: OLLAMA_API_KEY
           valueFrom:
@@ -670,11 +868,41 @@ spec:
               name: skyflo-secrets
               key: ollama-api-key
               optional: true
-        - name: GEMINI_API_KEY
+        - name: DEEPGRAM_API_KEY
           valueFrom:
             secretKeyRef:
               name: skyflo-secrets
-              key: gemini-api-key
+              key: deepgram-api-key
+              optional: true
+        - name: IBM_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: ibm-watsonx-api-key
+              optional: true
+        - name: PREDIBASE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: predibase-api-key
+              optional: true
+        - name: NVIDIA_NGC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: nvidia-nim-api-key
+              optional: true
+        - name: XAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: xai-api-key
+              optional: true
+        - name: VOLCENGINE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: volcengine-api-key
               optional: true
         - name: LLM_HOST
           valueFrom:

--- a/deployment/local.install.yaml
+++ b/deployment/local.install.yaml
@@ -10,11 +10,53 @@ metadata:
   namespace: skyflo-ai
 type: Opaque
 stringData:
+  # Core cloud LLMs
   openai-api-key: ${OPENAI_API_KEY}
   anthropic-api-key: ${ANTHROPIC_API_KEY}
-  groq-api-key: ${GROQ_API_KEY}
-  ollama-api-key: ${OLLAMA_API_KEY}
+  azure-api-key: ${AZURE_API_KEY}
   gemini-api-key: ${GEMINI_API_KEY}
+  cohere-api-key: ${COHERE_API_KEY}
+  mistral-api-key: ${MISTRAL_API_KEY}
+  groq-api-key: ${GROQ_API_KEY}
+  anyscale-api-key: ${ANYSCALE_API_KEY}
+  openrouter-api-key: ${OPENROUTER_API_KEY}
+  perplexity-api-key: ${PERPLEXITYAI_API_KEY}
+  fireworks-ai-api-key: ${FIREWORKS_AI_API_KEY}
+  togetherai-api-key: ${TOGETHERAI_API_KEY}
+  deepinfra-api-key: ${DEEPINFRA_API_KEY}
+  ai21-api-key: ${AI21_API_KEY}
+  nlp-cloud-api-key: ${NLP_CLOUD_API_KEY}
+  replicate-api-key: ${REPLICATE_API_KEY}
+  huggingface-token: ${HF_TOKEN}
+
+  # AWS / specialized back-ends
+  bedrock-aws-access-key-id: ${AWS_ACCESS_KEY_ID}
+  bedrock-aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  bedrock-aws-region-name: ${AWS_REGION_NAME}
+
+  # Other providers
+  databricks-token: ${DATABRICKS_TOKEN}
+  clarifai-pat: ${CLARIFAI_PAT}
+  voyage-api-key: ${VOYAGE_API_KEY}
+  jina-ai-api-key: ${JINAAI_API_KEY}
+  alephalpha-api-key: ${ALEPHALPHA_API_KEY}
+  baseten-api-key: ${BASETEN_API_KEY}
+  sambanova-api-key: ${SAMBANOVA_API_KEY}
+  snowflake-api-key: ${SNOWFLAKE_API_KEY}
+  featherless-api-key: ${FEATHERLESS_API_KEY}
+
+  # Local providers
+  ollama-api-key: ${OLLAMA_API_KEY}
+
+  # Audio/speech and misc endpoints
+  deepgram-api-key: ${DEEPGRAM_API_KEY}
+  ibm-watsonx-api-key: ${IBM_API_KEY}
+  predibase-api-key: ${PREDIBASE_API_KEY}
+  nvidia-nim-api-key: ${NVIDIA_NGC_API_KEY}
+  xai-api-key: ${XAI_API_KEY}
+  volcengine-api-key: ${VOLCENGINE_API_KEY}
+
+  # System configuration
   llm-host: ${LLM_HOST}
   llm-model: ${LLM_MODEL}
   jwt-secret: ${JWT_SECRET}
@@ -674,11 +716,167 @@ spec:
               name: skyflo-secrets
               key: anthropic-api-key
               optional: true
+        - name: AZURE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: azure-api-key
+              optional: true
+        - name: GEMINI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: gemini-api-key
+              optional: true
+        - name: COHERE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: cohere-api-key
+              optional: true
+        - name: MISTRAL_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: mistral-api-key
+              optional: true
         - name: GROQ_API_KEY
           valueFrom:
             secretKeyRef:
               name: skyflo-secrets
               key: groq-api-key
+              optional: true
+        - name: ANYSCALE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: anyscale-api-key
+              optional: true
+        - name: OPENROUTER_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: openrouter-api-key
+              optional: true
+        - name: PERPLEXITYAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: perplexity-api-key
+              optional: true
+        - name: FIREWORKS_AI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: fireworks-ai-api-key
+              optional: true
+        - name: TOGETHERAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: togetherai-api-key
+              optional: true
+        - name: DEEPINFRA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: deepinfra-api-key
+              optional: true
+        - name: AI21_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: ai21-api-key
+              optional: true
+        - name: NLP_CLOUD_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: nlp-cloud-api-key
+              optional: true
+        - name: REPLICATE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: replicate-api-key
+              optional: true
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: huggingface-token
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: bedrock-aws-access-key-id
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: bedrock-aws-secret-access-key
+              optional: true
+        - name: AWS_REGION_NAME
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: bedrock-aws-region-name
+              optional: true
+        - name: DATABRICKS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: databricks-token
+              optional: true
+        - name: CLARIFAI_PAT
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: clarifai-pat
+              optional: true
+        - name: VOYAGE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: voyage-api-key
+              optional: true
+        - name: JINAAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: jina-ai-api-key
+              optional: true
+        - name: ALEPHALPHA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: alephalpha-api-key
+              optional: true
+        - name: BASETEN_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: baseten-api-key
+              optional: true
+        - name: SAMBANOVA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: sambanova-api-key
+              optional: true
+        - name: SNOWFLAKE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: snowflake-api-key
+              optional: true
+        - name: FEATHERLESS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: featherless-api-key
               optional: true
         - name: OLLAMA_API_KEY
           valueFrom:
@@ -686,11 +884,41 @@ spec:
               name: skyflo-secrets
               key: ollama-api-key
               optional: true
-        - name: GEMINI_API_KEY
+        - name: DEEPGRAM_API_KEY
           valueFrom:
             secretKeyRef:
               name: skyflo-secrets
-              key: gemini-api-key
+              key: deepgram-api-key
+              optional: true
+        - name: IBM_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: ibm-watsonx-api-key
+              optional: true
+        - name: PREDIBASE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: predibase-api-key
+              optional: true
+        - name: NVIDIA_NGC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: nvidia-nim-api-key
+              optional: true
+        - name: XAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: xai-api-key
+              optional: true
+        - name: VOLCENGINE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: volcengine-api-key
               optional: true
         - name: LLM_HOST
           valueFrom:

--- a/deployment/local.install.yaml
+++ b/deployment/local.install.yaml
@@ -14,6 +14,7 @@ stringData:
   anthropic-api-key: ${ANTHROPIC_API_KEY}
   groq-api-key: ${GROQ_API_KEY}
   ollama-api-key: ${OLLAMA_API_KEY}
+  gemini-api-key: ${GEMINI_API_KEY}
   llm-host: ${LLM_HOST}
   llm-model: ${LLM_MODEL}
   jwt-secret: ${JWT_SECRET}
@@ -684,6 +685,12 @@ spec:
             secretKeyRef:
               name: skyflo-secrets
               key: ollama-api-key
+              optional: true
+        - name: GEMINI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: skyflo-secrets
+              key: gemini-api-key
               optional: true
         - name: LLM_HOST
           valueFrom:

--- a/deployment/local.install.yaml
+++ b/deployment/local.install.yaml
@@ -10,16 +10,17 @@ metadata:
   namespace: skyflo-ai
 type: Opaque
 stringData:
-  # Core cloud LLMs
+  # Major Cloud LLM Providers
   openai-api-key: ${OPENAI_API_KEY}
   anthropic-api-key: ${ANTHROPIC_API_KEY}
   azure-api-key: ${AZURE_API_KEY}
   gemini-api-key: ${GEMINI_API_KEY}
   cohere-api-key: ${COHERE_API_KEY}
   mistral-api-key: ${MISTRAL_API_KEY}
+
+  # Alternative LLM Providers
   groq-api-key: ${GROQ_API_KEY}
   anyscale-api-key: ${ANYSCALE_API_KEY}
-  openrouter-api-key: ${OPENROUTER_API_KEY}
   perplexity-api-key: ${PERPLEXITYAI_API_KEY}
   fireworks-ai-api-key: ${FIREWORKS_AI_API_KEY}
   togetherai-api-key: ${TOGETHERAI_API_KEY}
@@ -27,34 +28,31 @@ stringData:
   ai21-api-key: ${AI21_API_KEY}
   nlp-cloud-api-key: ${NLP_CLOUD_API_KEY}
   replicate-api-key: ${REPLICATE_API_KEY}
-  huggingface-token: ${HF_TOKEN}
-
-  # AWS / specialized back-ends
-  bedrock-aws-access-key-id: ${AWS_ACCESS_KEY_ID}
-  bedrock-aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
-  bedrock-aws-region-name: ${AWS_REGION_NAME}
-
-  # Other providers
-  databricks-token: ${DATABRICKS_TOKEN}
-  clarifai-pat: ${CLARIFAI_PAT}
-  voyage-api-key: ${VOYAGE_API_KEY}
   jina-ai-api-key: ${JINAAI_API_KEY}
   alephalpha-api-key: ${ALEPHALPHA_API_KEY}
+  voyage-api-key: ${VOYAGE_API_KEY}
+
+  # Enterprise & Research Providers
+  databricks-token: ${DATABRICKS_TOKEN}
+  clarifai-pat: ${CLARIFAI_PAT}
   baseten-api-key: ${BASETEN_API_KEY}
   sambanova-api-key: ${SAMBANOVA_API_KEY}
-  snowflake-api-key: ${SNOWFLAKE_API_KEY}
-  featherless-api-key: ${FEATHERLESS_API_KEY}
-
-  # Local providers
-  ollama-api-key: ${OLLAMA_API_KEY}
-
-  # Audio/speech and misc endpoints
-  deepgram-api-key: ${DEEPGRAM_API_KEY}
+  featherless-api-key: ${FEATHERLESS_AI_API_KEY}
   ibm-watsonx-api-key: ${IBM_API_KEY}
   predibase-api-key: ${PREDIBASE_API_KEY}
   nvidia-nim-api-key: ${NVIDIA_NGC_API_KEY}
   xai-api-key: ${XAI_API_KEY}
   volcengine-api-key: ${VOLCENGINE_API_KEY}
+
+  # Infrastructure & Routing
+  openrouter-api-key: ${OPENROUTER_API_KEY}
+  huggingface-token: ${HF_TOKEN}
+  bedrock-aws-access-key-id: ${AWS_ACCESS_KEY_ID}
+  bedrock-aws-secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+  bedrock-aws-region-name: ${AWS_REGION_NAME}
+
+  # Self-hosted / On-premise
+  ollama-api-key: ${OLLAMA_API_KEY}
 
   # System configuration
   llm-host: ${LLM_HOST}
@@ -866,13 +864,7 @@ spec:
               name: skyflo-secrets
               key: sambanova-api-key
               optional: true
-        - name: SNOWFLAKE_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: skyflo-secrets
-              key: snowflake-api-key
-              optional: true
-        - name: FEATHERLESS_API_KEY
+        - name: FEATHERLESS_AI_API_KEY
           valueFrom:
             secretKeyRef:
               name: skyflo-secrets
@@ -883,12 +875,6 @@ spec:
             secretKeyRef:
               name: skyflo-secrets
               key: ollama-api-key
-              optional: true
-        - name: DEEPGRAM_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: skyflo-secrets
-              key: deepgram-api-key
               optional: true
         - name: IBM_API_KEY
           valueFrom:

--- a/docs/install.md
+++ b/docs/install.md
@@ -53,7 +53,6 @@ Skyflo.ai offers two deployment options:
 Perfect for development, testing, and exploring Skyflo.ai features in a local environment:
 
 ```bash
-export OPENAI_API_KEY='your-openai-api-key'
 curl -sL https://raw.githubusercontent.com/skyflo-ai/skyflo/main/deployment/install.sh | bash
 ```
 
@@ -72,7 +71,6 @@ Access your local installation:
 For deploying Skyflo.ai in a production environment:
 
 ```bash
-export OPENAI_API_KEY='your-openai-api-key'
 curl -sL https://raw.githubusercontent.com/skyflo-ai/skyflo/main/deployment/install.sh -o install.sh && chmod +x install.sh && ./install.sh
 # Select option 2 when prompted
 ```


### PR DESCRIPTION
Adds support for every llm permitted by litellm 
The credentials to be used for the provider can be entered during install. This change supports one command install using any provider from bedrock to gemini. The exhaustive list of supported llms can be found [here](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)