### PR TITLE
fix (docs): architecture guide link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for considering contributing to Skyflo.ai! This document provides guid
 
 We are committed to providing a friendly, safe, and welcoming environment for all contributors. Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-We highly recommend reading our [Architecture Guide](ARCHITECTURE.md) if you'd like to contribute! The repo is not as intimidating as it first seems if you read the guide!
+We highly recommend reading our [Architecture Guide](/docs/architecture.md) if you'd like to contribute! The repo is not as intimidating as it first seems if you read the guide!
 
 ## Quick Start
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for considering contributing to Skyflo.ai! This document provides guid
 
 We are committed to providing a friendly, safe, and welcoming environment for all contributors. Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
-We highly recommend reading our [Architecture Guide](/docs/architecture.md) if you'd like to contribute! The repo is not as intimidating as it first seems if you read the guide!
+We highly recommend reading our [Architecture Guide](docs/architecture.md) if you'd like to contribute! The repo is not as intimidating as it first seems if you read the guide!
 
 ## Quick Start
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and which issue is fixed. Explain the motivation for the changes.

The architecture guide is incorrectly referenced in CONTRIBUTING.md; it should be /docs/architecture.md instead of just architecture.md.

## Related Issue(s)

Fixes #35

## Type of Change


- [x] Documentation update

## Testing

Please describe the tests you've added/performed to verify your changes.

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) for this project
- [x] I have added/updated necessary documentation
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass with my changes
- [x] I have checked for and resolved any merge conflicts
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] I have linked this PR to relevant issue(s)

## Screenshots (if applicable)

## Additional Notes 