### PR TITLE
feat (mcp): add Kubernetes rollout history tool to the MCP server

### DIFF
--- a/mcp/tools/kubectl.py
+++ b/mcp/tools/kubectl.py
@@ -285,6 +285,39 @@ async def k8s_rollout_undo(
 
 
 @mcp.tool(
+    title="View Kubernetes Rollout History",
+    tags=["k8s"],
+    annotations={"readOnlyHint": True},
+)
+async def k8s_rollout_history(
+    name: str = Field(description="The name of the resource to get rollout history for"),
+    resource_type: str = Field(
+        description="The type of resource to get rollout history for (deployment, daemonset, or statefulset)"
+    ),
+    namespace: Optional[str] = Field(
+        default="default", description="The namespace of the resource"
+    ),
+    revision: Optional[int] = Field(
+        default=None, description="Specific revision number to see details for. If not specified, shows all revisions"
+    ),
+) -> ToolOutput:
+    """View rollout history for a Kubernetes resource (deployment, daemonset, or statefulset)."""
+    valid_resource_types = ["deployment", "daemonset", "statefulset"]
+    if resource_type.lower() not in valid_resource_types:
+        raise ValueError(f"Invalid resource_type '{resource_type}'. Must be one of: {', '.join(valid_resource_types)}")
+    
+    cmd = f"rollout history {resource_type.lower()}/{name}"
+    
+    if namespace:
+        cmd += f" -n {namespace}"
+    
+    if revision is not None:
+        cmd += f" --revision={revision}"
+    
+    return await run_kubectl_command(cmd)
+
+
+@mcp.tool(
     title="Get Kubernetes Cluster Information",
     tags=["k8s"],
     annotations={"readOnlyHint": True},


### PR DESCRIPTION
# Description

Please include a summary of the changes and which issue is fixed. Explain the motivation for the changes.

Add k8s_rollout_history mcp tool for rollout history for Kubernetes resources (deployments, daemonsets, and statefulsets) using kubectl rollout history

## Related Issue(s)

Fixes #48 

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Documentation update
- [ ] Code refactor
- [ ] Performance improvement
- [ ] Tests
- [ ] Infrastructure/build changes
- [ ] Other (please describe):

## Testing

Please describe the tests you've added/performed to verify your changes.

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) for this project
- [ ] I have added/updated necessary documentation
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass with my changes
- [x] I have checked for and resolved any merge conflicts
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] I have linked this PR to relevant issue(s)

## Screenshots (if applicable)

## Additional Notes 