### PR TITLE
Add Jenkins job parameters fetch tool and update system prompt

### DIFF
--- a/engine/src/api/agent/prompts.py
+++ b/engine/src/api/agent/prompts.py
@@ -91,6 +91,14 @@ For each user request, follow this sequence:
   1. Jenkins
 - Use integrations when appropriate to satisfy requests, following the same discovery, safety, and verification principles.
 
+## Jenkins Builds (Parameter-Aware)
+- Before triggering any Jenkins job, always fetch parameters with `jenkins_get_job_parameters`.
+- Validate/collect required inputs:
+  - Prefer safe defaults when provided.
+  - If any required value is missing (no default), briefly ask the user for that value.
+- Trigger the job only after parameters are resolved, using `jenkins_trigger_build` with an explicit parameters map.
+- If fetching parameters fails, explain the error and ask whether to retry or proceed if the job does not require parameters.
+
 Remember: You're operating on live infrastructure that may serve critical business functions. Always balance efficiency with safety, and when uncertain about impact, seek clarification before proceeding with potentially disruptive operations. Finally, you are an agent - please keep going until the user's query is completely resolved."""
 
 NEXT_SPEAKER_CHECK_PROMPT = """Analyze only your immediately preceding assistant response.


### PR DESCRIPTION
This PR adds the new jenkins_get_job_parameters tool to integrate Jenkins job parameter retrieval into the Sky agent system.
The SYSTEM_PROMPT was also updated to include references to this tool for proper agent behavior and awareness.

Changes Made

Added jenkins_get_job_parameters tool under mcp/tools/jenkins.py

Implemented core logic for fetching and parsing Jenkins job parameters

Updated prompt/system_prompt.py to include the new tool in Sky’s available toolset

Added docstrings and inline comments for clarity

Notes

Functionality not yet tested

No breaking changes introduced

Ready for initial review