### PR TITLE
feat(ui): add TPS metric to token usage display

### DIFF
--- a/engine/src/api/agent/graph.py
+++ b/engine/src/api/agent/graph.py
@@ -297,6 +297,7 @@ class WorkflowGraph:
         end_time = time.time()
         start_time = get_state_value(state, "start_time", end_time)
         duration = end_time - start_time
+        duration_ms = int(duration * 1000)
 
         if self.event_callback:
             await self.event_callback(
@@ -305,6 +306,7 @@ class WorkflowGraph:
                     "status": "completed",
                     "run_id": get_state_value(state, "run_id"),
                     "duration": duration,
+                    "duration_ms": duration_ms,
                 }
             )
 
@@ -340,12 +342,19 @@ class WorkflowGraph:
                 result = await self.compiled_graph.ainvoke(initial_state, **kwargs)
                 return result
             except StopRequested:
+                end_time = time.time()
+                start_time = get_state_value(initial_state, "start_time", end_time)
+                duration = end_time - start_time
+                duration_ms = int(duration * 1000)
+
                 if self.event_callback:
                     await self.event_callback(
                         {
                             "type": "completed",
                             "status": "stopped",
                             "run_id": get_state_value(initial_state, "run_id"),
+                            "duration": duration,
+                            "duration_ms": duration_ms,
                         }
                     )
                 try:

--- a/engine/src/api/endpoints/agent.py
+++ b/engine/src/api/endpoints/agent.py
@@ -246,8 +246,10 @@ def create_event_callback(
                     result=event.get("result"),
                 )
             elif event_type == "completed":
-                duration = event.get("duration")
-                duration_ms = int(duration * 1000) if isinstance(duration, (int, float)) else None
+                duration_ms = event.get("duration_ms")
+                if duration_ms is None:
+                    duration = event.get("duration")
+                    duration_ms = int(duration * 1000) if isinstance(duration, (int, float)) else None
                 persistence.record_ttr(
                     conversation_id=conversation_id,
                     run_id=event_run_id,

--- a/ui/src/lib/services/sseService.ts
+++ b/ui/src/lib/services/sseService.ts
@@ -27,7 +27,7 @@ export interface ChatServiceCallbacks {
   onTokenUsage?: (usage: TokenUsage, source: "turn_check" | "main") => void;
   onTTFT?: (duration: number, runId: string) => void;
   onError?: (error: string) => void;
-  onComplete?: () => void;
+  onComplete?: (duration_ms?: number) => void;
   onReady?: (runId: string) => void;
 }
 
@@ -423,7 +423,8 @@ export class ChatService {
       case "completed":
         if (!this.hasCompleted) {
           this.hasCompleted = true;
-          this.callbacks.onComplete?.();
+          const completedEvent = event as CompletedEvent;
+          this.callbacks.onComplete?.(completedEvent.duration_ms);
         }
         break;
 

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -97,4 +97,5 @@ export interface TokenUsage {
   cached_tokens: number;
   ttft?: number;
   ttr?: number;
+  total_generation_ms?: number;
 }

--- a/ui/src/types/events.ts
+++ b/ui/src/types/events.ts
@@ -118,8 +118,9 @@ export interface ErrorEvent {
 
 export interface CompletedEvent {
   type: "completed";
-  status: "completed" | "error";
+  status: "completed" | "error" | "stopped";
   run_id?: string;
+  duration_ms?: number;
 }
 
 export interface WorkflowCompleteEvent {


### PR DESCRIPTION
## Summary
Adds a TPS (tokens per second) metric to the `TokenUsageDisplay` component to show token generation speed during LLM responses.

## Related Issue
Closes #72

## Changes Made
- Added `useMemo` hook to calculate TPS from `completion_tokens`, `ttr`, and `ttft`
- Formula: `completion_tokens / ((ttr - ttft) / 1000)` tokens per second
- Added TPS display with `MdSpeed` icon formatted as "X t/s"
- Added tooltip: "Generation Speed: X tokens/sec"
- Used `hasTPS` guard for consistent render pattern (matches `hasTokenUsage`, `hasTTFT`, `hasTTR`)
- Positioned after TTR metric in the usage bar
- Handles edge cases: null values, invalid calculations, division by zero

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] TypeScript compilation passes (`npm run build`)
- [x] Linting passes - no new errors introduced
- [x] Build succeeds in production mode
- [x] Code follows existing patterns and conventions
- [x] Follows Skyflo.ai coding standards (TypeScript, Airbnb style)

## Verification
```
✓ Compiled successfully
✓ Checking validity of types
✓ No linting errors in TokenUsageDisplay.tsx
✓ Build completed successfully
```

## Notes
- No new linting errors introduced - TokenUsageDisplay.tsx passes all checks
- Pre-existing linting errors in other files remain unchanged
- Implementation follows existing component patterns (`has*` naming convention)