### PR TITLE
ISSUE #80. Number of "any" reduced

### DIFF
--- a/ui/src/components/chat/ChatInterface.tsx
+++ b/ui/src/components/chat/ChatInterface.tsx
@@ -7,6 +7,8 @@ import {
   ChatMessage as ChatMessageType,
   ToolExecution as ToolExecutionType,
   MessageSegment,
+  ChatMessageDTO,
+  TokenUsageDTO
 } from "../../types/chat";
 import { ChatMessages } from "./ChatMessages";
 import { ChatInput } from "./ChatInput";
@@ -24,17 +26,16 @@ const createEmptyUsage = (): TokenUsage => ({
   total_generation_ms: 0,
 });
 
-const mapTokenUsage = (raw: any): TokenUsage | undefined => {
-  if (!raw || typeof raw !== "object") {
-    return undefined;
-  }
+const mapTokenUsage = (raw: TokenUsageDTO): TokenUsage | undefined => {
+  if (!raw) return undefined;
+
   return {
     prompt_tokens: Number(raw.prompt_tokens) || 0,
     completion_tokens: Number(raw.completion_tokens) || 0,
     total_tokens: Number(raw.total_tokens) || 0,
     cached_tokens: Number(raw.cached_tokens) || 0,
-    ttft: raw.ttft_ms ?? raw.ttft ?? undefined,
-    ttr: raw.ttr_ms ?? raw.ttr ?? undefined,
+    ttft: raw.ttft_ms  ?? undefined,
+    ttr: raw.ttr_ms ?? undefined,
   };
 };
 
@@ -131,9 +132,9 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps) {
       const lastMessage = messages[messages.length - 1];
       if (
         lastMessage?.type === "assistant" &&
-        (lastMessage as any).segments?.length
+        (lastMessage as ChatMessage).segments?.length
       ) {
-        const segments = (lastMessage as any).segments;
+        const segments = (lastMessage as ChatMessage).segments;
         return segments[segments.length - 1];
       }
 
@@ -221,7 +222,7 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps) {
     result: execution.result,
     timestamp: execution.timestamp,
     error: execution.error,
-    requires_approval: (execution as any).requires_approval,
+    requires_approval: execution.requires_approval,
   });
 
   const updateMessageWithTool = useCallback(
@@ -700,7 +701,7 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps) {
         const msgs = Array.isArray(data?.messages) ? data.messages : [];
         if (!isMounted) return;
 
-        const hydrated: ChatMessageType[] = msgs.map((m: any) => {
+        const hydrated: ChatMessageType[] = msgs.map((m: ChatMessageDTO) => {
           const baseMessage: ChatMessageType = {
             id: m.id || crypto.randomUUID(),
             type: m.type,
@@ -1026,7 +1027,7 @@ export function ChatInterface({ conversationId }: ChatInterfaceProps) {
       }
     };
 
-    addSegments(currentMessage?.segments as any);
+    addSegments(currentMessage?.segments ?? []);
 
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i] as any;

--- a/ui/src/types/chat.ts
+++ b/ui/src/types/chat.ts
@@ -34,7 +34,7 @@ export type MessageSegment =
       toolExecution: ToolExecution;
       timestamp?: number;
     };
-
+    
 export interface ChatMessage {
   id: string;
   type: "user" | "assistant";
@@ -43,6 +43,16 @@ export interface ChatMessage {
   isStreaming?: boolean;
   segments?: MessageSegment[];
   tokenUsage?: TokenUsage;
+}
+
+export interface ChatMessageDTO {
+  id?: string;
+  type: "user" | "assistant";
+  content?: string;
+  timestamp?: number;
+  isStreaming?: boolean;
+  segments?: MessageSegment[];
+  token_usage?: TokenUsage;
 }
 
 export interface ChatState {
@@ -98,4 +108,14 @@ export interface TokenUsage {
   ttft?: number;
   ttr?: number;
   total_generation_ms?: number;
+}
+
+export interface TokenUsageDTO {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  cached_tokens?: number;
+  cost?: number;
+  ttft_ms?: number | null;
+  ttr_ms?: number | null;
 }


### PR DESCRIPTION
There were 35 "any" used in ChatInterface.tsx I reduced it to 30:

2 DTOs were created

<img width="384" height="233" alt="grafik" src="https://github.com/user-attachments/assets/b53997ab-f63c-4b99-b5ba-7a0da4ebcea0" />
<img width="338" height="220" alt="grafik" src="https://github.com/user-attachments/assets/095d87ed-2640-46df-b4e2-05d8a6f93dec" />

MapTokenUsage has no any anymore

<img width="734" height="286" alt="grafik" src="https://github.com/user-attachments/assets/be246c9f-bc6a-4246-bdf0-2c7406ae9e53" />


Each mesage from msgs have no any anymore

<img width="734" height="231" alt="grafik" src="https://github.com/user-attachments/assets/26eec534-1695-4616-a234-adc270e0fb44" />

The segments of the current message have no any anymore

<img width="507" height="71" alt="grafik" src="https://github.com/user-attachments/assets/39555422-6385-4792-8b44-89459c7b23c7" />

