### PR TITLE
Add engine init containers for DB/Redis readiness

### DIFF
--- a/deployment/engine/entrypoint.sh
+++ b/deployment/engine/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# Wait for 30 seconds for the database to be ready
-sleep 30
-
 # Initialize Aerich if not already initialized
 if [ ! -d "migrations" ]; then
   echo "Initializing Aerich..."

--- a/deployment/install.yaml
+++ b/deployment/install.yaml
@@ -697,6 +697,41 @@ spec:
       labels:
         app: skyflo-ai-engine
     spec:
+      initContainers:
+      - name: wait-for-postgres
+        image: busybox:1.36
+        command: ['sh', '-c', 'timeout=300; elapsed=0; until nc -z skyflo-ai-postgres 5432; do echo "Waiting for Postgres..."; sleep 2; elapsed=$((elapsed+2)); if [ $elapsed -ge $timeout ]; then echo "Timed out waiting for Postgres"; exit 1; fi; done']
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 1002
+          runAsGroup: 1002
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+      - name: wait-for-redis
+        image: busybox:1.36
+        command: ['sh', '-c', 'timeout=300; elapsed=0; until nc -z skyflo-ai-redis 6379; do echo "Waiting for Redis..."; sleep 2; elapsed=$((elapsed+2)); if [ $elapsed -ge $timeout ]; then echo "Timed out waiting for Redis"; exit 1; fi; done']
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 1002
+          runAsGroup: 1002
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
       containers:
       - name: engine
         image: skyfloaiagent/engine:${VERSION}
@@ -727,7 +762,7 @@ spec:
           httpGet:
             path: /api/v1/health
             port: http
-          initialDelaySeconds: 60
+          initialDelaySeconds: 10
           timeoutSeconds: 5
           periodSeconds: 10
           failureThreshold: 3
@@ -735,7 +770,7 @@ spec:
           httpGet:
             path: /api/v1/health
             port: http
-          initialDelaySeconds: 60
+          initialDelaySeconds: 15
           timeoutSeconds: 5
           periodSeconds: 10
           failureThreshold: 3

--- a/deployment/local.install.yaml
+++ b/deployment/local.install.yaml
@@ -744,6 +744,41 @@ spec:
       labels:
         app: skyflo-ai-engine
     spec:
+      initContainers:
+      - name: wait-for-postgres
+        image: busybox:1.36
+        command: ['sh', '-c', 'timeout=300; elapsed=0; until nc -z skyflo-ai-postgres 5432; do echo "Waiting for Postgres..."; sleep 2; elapsed=$((elapsed+2)); if [ $elapsed -ge $timeout ]; then echo "Timed out waiting for Postgres"; exit 1; fi; done']
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 1002
+          runAsGroup: 1002
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+      - name: wait-for-redis
+        image: busybox:1.36
+        command: ['sh', '-c', 'timeout=300; elapsed=0; until nc -z skyflo-ai-redis 6379; do echo "Waiting for Redis..."; sleep 2; elapsed=$((elapsed+2)); if [ $elapsed -ge $timeout ]; then echo "Timed out waiting for Redis"; exit 1; fi; done']
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 1002
+          runAsGroup: 1002
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
       containers:
       - name: engine
         image: skyfloaiagent/engine:${VERSION}
@@ -774,7 +809,7 @@ spec:
           httpGet:
             path: /api/v1/health
             port: http
-          initialDelaySeconds: 60
+          initialDelaySeconds: 10
           timeoutSeconds: 5
           periodSeconds: 5
           failureThreshold: 3
@@ -782,7 +817,7 @@ spec:
           httpGet:
             path: /api/v1/health
             port: http
-          initialDelaySeconds: 60
+          initialDelaySeconds: 15
           timeoutSeconds: 5
           periodSeconds: 5
           failureThreshold: 3


### PR DESCRIPTION
- Add wait-for-postgres and wait-for-redis init containers to engine Deployment in install.yaml and local.install.yaml (busybox:1.36, nc check)
- Set init container securityContext to match engine (runAsUser/runAsGroup 1002, allowPrivilegeEscalation false, capabilities drop ALL)

# Description

Please include a summary of the changes and the motivation behind them.

## Related Issue(s)

Fixes #98

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Documentation update
- [x] Code refactor
- [x] Performance improvement
- [x] Tests
- [x] Infrastructure/build changes
- [ ] Other (please describe):

## Testing

Please describe the tests you've added/performed to verify your changes.
Steps that i followed for testing the change:

**1.Apply** : Ran kubectl apply -f deployment/install.yaml  and confirmed all resources applied.

**2.Pods :**  Ran kubectl get pods -n default and checked that controller, engine, MCP, Postgres, Redis, and UI pods reached Running (engine 1/1, UI 2/2).

**3.Init containers:** Ran kubectl describe pod -l app=skyflo-ai-engine -n default and confirmed both init containers (wait-for-postgres, wait-for-redis) completed and the main engine container started after them.
Checked init logs with kubectl logs <engine-pod> -c wait-for-postgres and -c wait-for-redis to confirm they wait when dependencies are down and exit when they’re up.

**4.Engine and UI:** Port-forwarded the UI service and opened the app in the browser to confirm it loads.

**5.Optional:** `dependency down
Scaled Postgres to 0, restarted the engine deployment, and saw the engine pod stay in Init until Postgres was scaled back up and became ready.



**Output after chnage apply:**

```
kubectl get pods -n default
NAME                                    READY   STATUS            RESTARTS   AGE
skyflo-ai-controller-84d4bcb79b-hmcbw   1/1     Running           0          55s
skyflo-ai-engine-589b776c49-42jvd       0/1     PodInitializing   0          55s
skyflo-ai-mcp-7d86745958-hzcr8          0/1     Running           0          55s
skyflo-ai-postgres-0                    1/1     Running           0          55s
skyflo-ai-redis-0                       1/1     Running           0          55s
skyflo-ai-ui-5cdc88f555-dqjr7           2/2     Running           0          55s
```


```
kubectl get pods -n default
NAME                                    READY   STATUS    RESTARTS   AGE
skyflo-ai-controller-84d4bcb79b-hmcbw   1/1     Running   0          94s
skyflo-ai-engine-589b776c49-42jvd       0/1     Running   0          94s
skyflo-ai-mcp-7d86745958-hzcr8          1/1     Running   0          94s
skyflo-ai-postgres-0                    1/1     Running   0          94s
skyflo-ai-redis-0                       1/1     Running   0          94s
skyflo-ai-ui-5cdc88f555-dqjr7           2/2     Running   0          94s
```


## Checklist

### Before Requesting Review

- [x] I have tested my changes locally
- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards)
- [ ] I have added/updated necessary documentation
- [x] I have checked for and resolved any merge conflicts
- [x] I have linked this PR to relevant issue(s)

### Code Quality

- [ ] No debug `print` statements or `console.log` calls
- [ ] No `package-lock.json` (we use `yarn` only for the UI)
- [ ] No redundant or self-explanatory comments
- [ ] Error handling does not expose internal details to users

## Screenshots (if applicable)

## Additional Notes