### PR TITLE
Add UI proxy probes

### DIFF
--- a/deployment/install.yaml
+++ b/deployment/install.yaml
@@ -45,7 +45,6 @@ stringData:
   JWT_SECRET: "${JWT_SECRET}"
   POSTGRES_DATABASE_URL: "${POSTGRES_DATABASE_URL}"
   REDIS_URL: "${REDIS_URL}"
-
 ---
 apiVersion: v1
 kind: Secret
@@ -58,7 +57,6 @@ stringData:
   POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
   POSTGRES_DB: "${POSTGRES_DB}"
   POSTGRES_PORT: "${POSTGRES_PORT}"
-  
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -649,7 +647,7 @@ spec:
           httpGet:
             path: /
             port: 3000
-          initialDelaySeconds: 15
+          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
@@ -681,7 +679,7 @@ spec:
           httpGet:
             path: /health
             port: 80
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
@@ -689,7 +687,7 @@ spec:
           httpGet:
             path: /health
             port: 80
-          initialDelaySeconds: 10
+          initialDelaySeconds: 15
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3

--- a/deployment/local.install.yaml
+++ b/deployment/local.install.yaml
@@ -693,7 +693,7 @@ spec:
           httpGet:
             path: /
             port: 3000
-          initialDelaySeconds: 15
+          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
@@ -707,7 +707,7 @@ spec:
           failureThreshold: 3
       - name: proxy
         image: skyfloaiagent/proxy:${VERSION}
-        imagePullPolicy: Never
+        imagePullPolicy: Always
         ports:
         - containerPort: 80
           name: http-proxy
@@ -725,7 +725,7 @@ spec:
           httpGet:
             path: /health
             port: 80
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
@@ -733,7 +733,7 @@ spec:
           httpGet:
             path: /health
             port: 80
-          initialDelaySeconds: 10
+          initialDelaySeconds: 15
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3

--- a/deployment/ui/nginx.conf
+++ b/deployment/ui/nginx.conf
@@ -3,11 +3,11 @@ server {
 
     server_name localhost;
 
-    # Health endpoint for k8s probes; does not proxy to backend
-    location = /health {
+    # Health check for k8s probes; does not proxy to upstreams
+    location /health {
         access_log off;
-        return 200 "OK";
-        add_header Content-Type text/plain;
+        default_type text/plain;
+        return 200 'OK';
     }
 
     location /api/v1/ {


### PR DESCRIPTION
# Description

Please include a summary of the changes and the motivation behind them.

Added readiness/liveness probes for UI and proxy, add /health for proxy

- Added HTTP readiness and liveness probes to UI (port 3000, path /) and proxy (port 80, path /health) in install.yaml and local.install.yaml
- Added location /health in nginx.conf so proxy answers health checks directly and avoids 502 from proxying to unready backend

Output after the chnage:

```
kubectl get pods -n default
NAME                                    READY   STATUS    RESTARTS       AGE
skyflo-ai-controller-84d4bcb79b-wrpvp   1/1     Running   0              5m35s
skyflo-ai-engine-9dd448c85-f5whw        1/1     Running   1 (2m9s ago)   5m35s
skyflo-ai-mcp-7d86745958-74h2p          1/1     Running   0              5m35s
skyflo-ai-postgres-0                    1/1     Running   0              5m35s
skyflo-ai-redis-0                       1/1     Running   0              5m35s
skyflo-ai-ui-7cffc646cb-4mpq9           2/2     Running   0              5m35s
```
```kubectl exec  skyflo-ai-ui-7cffc646cb-4mpq9 -c proxy -- kill 1```


```
kubectl get pods
NAME                                    READY   STATUS     RESTARTS        AGE
skyflo-ai-controller-84d4bcb79b-wrpvp   1/1     Running    0               5m51s
skyflo-ai-engine-9dd448c85-f5whw        1/1     Running    1 (2m25s ago)   5m51s
skyflo-ai-mcp-7d86745958-74h2p          1/1     Running    0               5m51s
skyflo-ai-postgres-0                    1/1     Running    0               5m51s
skyflo-ai-redis-0                       1/1     Running    0               5m51s
skyflo-ai-ui-7cffc646cb-4mpq9           1/2     NotReady   0               5m51s
```


```
kubectl get pods
NAME                                    READY   STATUS    RESTARTS        AGE
skyflo-ai-controller-84d4bcb79b-wrpvp   1/1     Running   0               6m12s
skyflo-ai-engine-9dd448c85-f5whw        1/1     Running   1 (2m46s ago)   6m12s
skyflo-ai-mcp-7d86745958-74h2p          1/1     Running   0               6m12s
skyflo-ai-postgres-0                    1/1     Running   0               6m12s
skyflo-ai-redis-0                       1/1     Running   0               6m12s
skyflo-ai-ui-7cffc646cb-4mpq9           2/2     Running   1 (22s ago)     6m12s
```

## Related Issue(s)

Fixes #

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Documentation update
- [x] Code refactor
- [x] Performance improvement
- [x] Tests
- [x] Infrastructure/build changes
- [ ] Other (please describe):

## Testing

Please describe the tests you've added/performed to verify your changes.

## Checklist

### Before Requesting Review

- [x] I have tested my changes locally
- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards)
- [ ] I have added/updated necessary documentation
- [x] I have checked for and resolved any merge conflicts
- [x] I have linked this PR to relevant issue(s)

### Code Quality

- [ ] No debug `print` statements or `console.log` calls
- [ ] No `package-lock.json` (we use `yarn` only for the UI)
- [ ] No redundant or self-explanatory comments
- [ ] Error handling does not expose internal details to users

## Screenshots (if applicable)

## Additional Notes
**Why we changed `deployment/ui/nginx.conf`**
The proxy’s readiness and liveness probes were hitting path / on port 80. Nginx serves / by proxying to the UI at http://skyflo-ai-ui:3000. The pod is only added to the Service’s endpoints when it is Ready, and the proxy only becomes Ready when its probe gets a 2xx. So the probe hit the proxy → proxy called the Service → the Service had no Ready pods (including this one) → no backend → 502. That kept the proxy (and the pod) from ever becoming Ready.
We added a location /health that nginx handles itself (no proxy_pass), returning 200 "ok". Probes now use path /health for the proxy, so they no longer depend on the UI or the Service. That removes the circular dependency and allows the proxy to become Ready and stay healthy.

Got this error when running nginx  container without any change in nginx.conf.

```
  Normal   Scheduled  2m31s                default-scheduler  Successfully assigned default/skyflo-ai-ui-687d8495c9-c8fxx to docker-desktop
  Normal   Pulling    2m31s                kubelet            Pulling image "skyfloaiagent/ui:v0.5.0"
  Normal   Pulled     2m26s                kubelet            Successfully pulled image "skyfloaiagent/ui:v0.5.0" in 2.439s (4.873s including waiting). Image size: 275730359 bytes.
  Normal   Created    2m26s                kubelet            Created container: ui
  Normal   Started    2m26s                kubelet            Started container ui
  Normal   Pulled     2m21s                kubelet            Successfully pulled image "skyfloaiagent/proxy:v0.5.0" in 2.518s (4.926s including waiting). Image size: 49697197 bytes.
  Normal   Pulled     108s                 kubelet            Successfully pulled image "skyfloaiagent/proxy:v0.5.0" in 2.468s (2.468s including waiting). Image size: 49697197 bytes.
  Normal   Pulled     68s                  kubelet            Successfully pulled image "skyfloaiagent/proxy:v0.5.0" in 2.408s (2.408s including waiting). Image size: 49697197 bytes.
  Normal   Pulling    31s (x4 over 2m26s)  kubelet            Pulling image "skyfloaiagent/proxy:v0.5.0"
  Normal   Killing    31s (x3 over 111s)   kubelet            Container proxy failed liveness probe, will be restarted
  Normal   Created    28s (x4 over 2m21s)  kubelet            Created container: proxy
  Normal   Started    28s (x4 over 2m21s)  kubelet            Started container proxy
  Normal   Pulled     28s                  kubelet            Successfully pulled image "skyfloaiagent/proxy:v0.5.0" in 2.702s (2.702s including waiting). Image size: 49697197 bytes.
  Warning  Unhealthy  5s (x14 over 2m8s)   kubelet            Readiness probe failed: HTTP probe failed with statuscode: 502
  Warning  Unhealthy  1s (x11 over 2m11s)  kubelet            Liveness probe failed: HTTP probe failed with statuscode: 502
```

**Why we need to update the Docker image and push a new image**
The proxy container is built from deployment/ui/proxy.Dockerfile, which copies **deployment/ui/nginx.conf** into the image. The new /health behaviour only exists in the cluster after that updated nginx config is inside the image. So you must rebuild the proxy image (so it includes the new nginx.conf), push it to your registry with the tag your manifests use (e.g. skyfloaiagent/proxy:v0.5.0), and redeploy (e.g. kubectl rollout restart deployment/skyflo-ai-ui) so pods pull the new image. Until then, the running proxy will keep proxying /health to the UI and probes will keep getting 502.