### PR TITLE
feat (infra): Added probes for UI and Proxy containers.

### DIFF
--- a/deployment/install.yaml
+++ b/deployment/install.yaml
@@ -643,6 +643,22 @@ spec:
           capabilities:
             drop:
             - ALL
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
       - name: proxy
         image: skyfloaiagent/proxy:${VERSION}
         imagePullPolicy: Always
@@ -659,6 +675,22 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http-proxy
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http-proxy
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
       securityContext:
         runAsNonRoot: false
       terminationGracePeriodSeconds: 10

--- a/deployment/local.install.yaml
+++ b/deployment/local.install.yaml
@@ -689,6 +689,22 @@ spec:
           capabilities:
             drop:
             - ALL
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /api/health
+            port: http
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
       - name: proxy
         image: skyfloaiagent/proxy:${VERSION}
         imagePullPolicy: Never
@@ -705,6 +721,22 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http-proxy
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http-proxy
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
       securityContext:
         runAsNonRoot: false
       terminationGracePeriodSeconds: 10

--- a/deployment/ui/nginx.conf
+++ b/deployment/ui/nginx.conf
@@ -3,6 +3,12 @@ server {
 
     server_name localhost;
 
+    location = /health {
+        access_log off;
+        default_type text/plain;
+        return 200 'ok';
+    }
+
     location /api/v1/ {
         proxy_pass http://skyflo-ai-engine:8080/api/v1/;
         proxy_http_version 1.1;

--- a/ui/src/app/api/health/route.ts
+++ b/ui/src/app/api/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ status: "ok" });
+}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the motivation behind them.

**Added readiness/liveness probes for UI and proxy, add /health for proxy**

- Added HTTP readiness and liveness probes to UI (port 3000, path /) and proxy (port 80, path /health) in install.yaml and local.install.yaml
- Added location /health in nginx.conf so proxy answers health checks directly and avoids 502 from proxying to unready backend

**Output after the change:**

```
kubectl get pods -n default
NAME                                    READY   STATUS    RESTARTS       AGE
skyflo-ai-controller-84d4bcb79b-wrpvp   1/1     Running   0              5m35s
skyflo-ai-engine-9dd448c85-f5whw        1/1     Running   1 (2m9s ago)   5m35s
skyflo-ai-mcp-7d86745958-74h2p          1/1     Running   0              5m35s
skyflo-ai-postgres-0                    1/1     Running   0              5m35s
skyflo-ai-redis-0                       1/1     Running   0              5m35s
skyflo-ai-ui-7cffc646cb-4mpq9           2/2     Running   0              5m35s
```
```kubectl exec  skyflo-ai-ui-7cffc646cb-4mpq9 -c proxy -- kill 1```


```
kubectl get pods
NAME                                    READY   STATUS     RESTARTS        AGE
skyflo-ai-controller-84d4bcb79b-wrpvp   1/1     Running    0               5m51s
skyflo-ai-engine-9dd448c85-f5whw        1/1     Running    1 (2m25s ago)   5m51s
skyflo-ai-mcp-7d86745958-74h2p          1/1     Running    0               5m51s
skyflo-ai-postgres-0                    1/1     Running    0               5m51s
skyflo-ai-redis-0                       1/1     Running    0               5m51s
skyflo-ai-ui-7cffc646cb-4mpq9           1/2     NotReady   0               5m51s
```


```
kubectl get pods
NAME                                    READY   STATUS    RESTARTS        AGE
skyflo-ai-controller-84d4bcb79b-wrpvp   1/1     Running   0               6m12s
skyflo-ai-engine-9dd448c85-f5whw        1/1     Running   1 (2m46s ago)   6m12s
skyflo-ai-mcp-7d86745958-74h2p          1/1     Running   0               6m12s
skyflo-ai-postgres-0                    1/1     Running   0               6m12s
skyflo-ai-redis-0                       1/1     Running   0               6m12s
skyflo-ai-ui-7cffc646cb-4mpq9           2/2     Running   1 (22s ago)     6m12s
```


```
kubectl port-forward -n default deployment/skyflo-ai-ui 3000:80
Forwarding from 127.0.0.1:3000 -> 80
Forwarding from [::1]:3000 -> 80
Handling connection for 3000
```
```
curl -s http://localhost:3000/api/health

{"ok":true}%
```

```
kubectl describe pod -n default -l app=skyflo-ai-ui | grep -A 8 "Liveness:\|Readiness:"
    Liveness:   http-get http://:3000/api/health delay=15s timeout=5s period=10s #success=1 #failure=3
    Readiness:  http-get http://:3000/api/health delay=10s timeout=5s period=10s #success=1 #failure=3
    Environment Variables from:
      skyflo-ui-config  ConfigMap  Optional: false
    Environment:
      APP_VERSION:  v0.5.0
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-kdh9f (ro)
  proxy:
    Container ID:   docker://f99ee5195ea62df5b0d167109af804ab87f261cfa3326906345aa9b6abf5c222
--
    Liveness:   http-get http://:80/health delay=15s timeout=5s period=10s #success=1 #failure=3
    Readiness:  http-get http://:80/health delay=10s timeout=5s period=10s #success=1 #failure=3
    Environment:
      APP_VERSION:  v0.5.0
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-kdh9f (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
```


## Related Issue(s)

Fixes #93 

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Documentation update
- [x] Code refactor
- [x] Performance improvement
- [x] Tests
- [x] Infrastructure/build changes
- [ ] Other (please describe):

## Testing

Please describe the tests you've added/performed to verify your changes.

## Checklist

### Before Requesting Review

- [x] I have tested my changes locally
- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards)
- [ ] I have added/updated necessary documentation
- [x] I have checked for and resolved any merge conflicts
- [x] I have linked this PR to relevant issue(s)

### Code Quality

- [ ] No debug `print` statements or `console.log` calls
- [ ] No `package-lock.json` (we use `yarn` only for the UI)
- [ ] No redundant or self-explanatory comments
- [ ] Error handling does not expose internal details to users

## Screenshots (if applicable)

## Additional Notes


**Why we changed deployment/ui/nginx.conf**
The proxy’s readiness and liveness probes were using path / on port 80. Nginx serves / by proxying to the UI at http://skyflo-ai-ui:3000. The pod is only added to the Service’s endpoints when it is Ready, and the proxy only becomes Ready when its probe gets a 2xx. So the probe hit the proxy → proxy called the Service → the Service had no Ready pods (including this one) → no backend → 502. That kept the proxy (and the pod) from ever becoming Ready.
We added a location = /health that nginx handles itself (no proxy_pass), returning 200 "OK". Probes now use path /health for the proxy, so they no longer depend on the UI or the Service. That removes the circular dependency and allows the proxy to become Ready and stay healthy.

Got this error when running nginx  container without any change in nginx.conf.

```
  Normal   Scheduled  2m31s                default-scheduler  Successfully assigned default/skyflo-ai-ui-687d8495c9-c8fxx to docker-desktop
  Normal   Pulling    2m31s                kubelet            Pulling image "skyfloaiagent/ui:v0.5.0"
  Normal   Pulled     2m26s                kubelet            Successfully pulled image "skyfloaiagent/ui:v0.5.0" in 2.439s (4.873s including waiting). Image size: 275730359 bytes.
  Normal   Created    2m26s                kubelet            Created container: ui
  Normal   Started    2m26s                kubelet            Started container ui
  Normal   Pulled     2m21s                kubelet            Successfully pulled image "skyfloaiagent/proxy:v0.5.0" in 2.518s (4.926s including waiting). Image size: 49697197 bytes.
  Normal   Pulled     108s                 kubelet            Successfully pulled image "skyfloaiagent/proxy:v0.5.0" in 2.468s (2.468s including waiting). Image size: 49697197 bytes.
  Normal   Pulled     68s                  kubelet            Successfully pulled image "skyfloaiagent/proxy:v0.5.0" in 2.408s (2.408s including waiting). Image size: 49697197 bytes.
  Normal   Pulling    31s (x4 over 2m26s)  kubelet            Pulling image "skyfloaiagent/proxy:v0.5.0"
  Normal   Killing    31s (x3 over 111s)   kubelet            Container proxy failed liveness probe, will be restarted
  Normal   Created    28s (x4 over 2m21s)  kubelet            Created container: proxy
  Normal   Started    28s (x4 over 2m21s)  kubelet            Started container proxy
  Normal   Pulled     28s                  kubelet            Successfully pulled image "skyfloaiagent/proxy:v0.5.0" in 2.702s (2.702s including waiting). Image size: 49697197 bytes.
  Warning  Unhealthy  5s (x14 over 2m8s)   kubelet            Readiness probe failed: HTTP probe failed with statuscode: 502
  Warning  Unhealthy  1s (x11 over 2m11s)  kubelet            Liveness probe failed: HTTP probe failed with statuscode: 502
```

**Why we added UI /api/health**
The UI probes originally used path / on port 3000. That triggers full page rendering and is heavier and less reliable for frequent probes. We added a minimal Next.js API route at /api/health that returns { "ok": true } with no rendering or external calls, so readiness/liveness checks are cheap and stable. Probes were updated to use /api/health instead of /.



**Why we need to rebuild and push new images**
**_Proxy:_** The proxy container is built from deployment/ui/proxy.Dockerfile, which copies deployment/ui/nginx.conf into the image. The new /health behaviour only exists in the cluster after that updated nginx config is inside the image. You must rebuild the proxy image (so it includes the new nginx.conf), push it to your registry with the tag your manifests use (e.g. skyfloaiagent/proxy:v0.5.0), and redeploy (e.g. kubectl rollout restart deployment/skyflo-ai-ui) so pods use the new image. Until then, the running proxy will keep proxying /health to the UI and probes can keep getting 502.
**_UI:_** The UI image must include the new /api/health route (e.g. ui/src/app/api/health/route.ts). Rebuild the UI image, push it with the tag used in the manifests (e.g. skyfloaiagent/ui:v0.5.0), and redeploy so probes to /api/health succeed.



