### PR TITLE
Verify MCP connectivity at startup in engine with retry and backoff

### DIFF
--- a/engine/src/api/asgi.py
+++ b/engine/src/api/asgi.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 
@@ -8,6 +9,7 @@ from .endpoints import api_router
 from .middleware import setup_middleware
 from .services.checkpointer import close_graph_checkpointer, init_graph_checkpointer
 from .services.limiter import close_limiter, init_limiter
+from .services.mcp_client import MCPClient
 
 logging.basicConfig(
     level=getattr(logging, settings.LOG_LEVEL),
@@ -16,10 +18,42 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+MCP_RETRY_ATTEMPTS = 5
+MCP_RETRY_DELAY = 3
+
+
+async def verify_mcp_connection() -> None:
+    last_error: Exception | None = None
+
+    for attempt in range(1, MCP_RETRY_ATTEMPTS + 1):
+        try:
+            client = MCPClient()
+            tools = await client.list_tools_raw()
+            logger.info(
+                "MCP server %s connected successfully. Available tools: %d",
+                client.mcp_url,
+                len(tools),
+            )
+            return
+        except Exception as e:
+            last_error = e
+            logger.warning(
+                "MCP connection attempt %d/%d failed: %s",
+                attempt,
+                MCP_RETRY_ATTEMPTS,
+                str(e),
+            )
+            if attempt < MCP_RETRY_ATTEMPTS:
+                await asyncio.sleep(MCP_RETRY_DELAY)
+    raise RuntimeError(
+        f"MCP server unreachable after {MCP_RETRY_ATTEMPTS} attempts. Last error: {last_error}"
+    ) from last_error
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info(f"Starting {settings.APP_NAME} version {settings.APP_VERSION}")
+    await verify_mcp_connection()
     await init_db()
     await init_limiter()
     await init_graph_checkpointer()


### PR DESCRIPTION
# Description

This PR adds verifiable MCP Connectivity at startup in engine

## Related Issue(s)

Fixes #113 

## Type of Change

- [x] Feature (new functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Documentation update
- [ ] Code refactor
- [ ] Performance improvement
- [ ] Tests
- [ ] Infrastructure/build changes
- [ ] Other (please describe):

## Testing

Please describe the tests you've added/performed to verify your changes.

## Checklist

### Before Requesting Review

- [x] I have tested my changes locally
- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards)
- [x] I have added/updated necessary documentation
- [x] I have checked for and resolved any merge conflicts
- [x] I have linked this PR to relevant issue(s)

### Code Quality

- [x] No debug `print` statements or `console.log` calls
- [x] No `package-lock.json` (we use `yarn` only for the UI)
- [x] No redundant or self-explanatory comments
- [x] Error handling does not expose internal details to users

## Screenshots (if applicable)

## Additional Notes