### PR TITLE
fix (UI): sign in automatically after initial admin registration

### DIFF
--- a/ui/src/components/auth/Register.tsx
+++ b/ui/src/components/auth/Register.tsx
@@ -6,8 +6,10 @@ import { Button } from "@/components/ui/button";
 import { AuthInput } from "./AuthInput";
 import { MdLock, MdEmail, MdPerson } from "react-icons/md";
 import { handleRegistration } from "@/lib/auth";
+import { useAuthStore } from "@/store/useAuthStore";
 
 export const Register = () => {
+  const { login } = useAuthStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isMounted, setIsMounted] = useState(false);
@@ -28,7 +30,8 @@ export const Register = () => {
     const result = await handleRegistration(formData);
 
     if (result && result.success) {
-      router.push("/login");
+      login(result.user, result.token);
+      router.push("/");
     } else {
       setError(result?.error || "Registration failed");
     }

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -122,9 +122,16 @@ export async function handleRegistration(
     );
 
     if (response.ok) {
-      const userData = await response.json();
+      await response.json().catch(() => undefined);
 
-      return { success: true, user: userData, token: "" };
+      const loginResult = await handleLogin(formData);
+      if (loginResult.success) {
+        return loginResult;
+      }
+      return {
+        success: false,
+        error: `Account created, but sign-in did not finish. Use the same email and password on the sign-in page. (${loginResult.error})`,
+      };
     } else {
       return { success: false, error: "Registration failed" };
     }


### PR DESCRIPTION
# Description
After the first-time admin registers on /welcome, the app now signs them in automatically (same flow as /login: JWT, httpOnly cookies, refresh token, /auth/me) and sends them to /. 
If registration succeeds but auto sign-in fails, a short inline error explains that the account exists and they should sign in manually with the same credentials.

New admins were redirected without a session and had to open /login and enter the same password again. This removes that broken first-run experience and aligns welcome registration with normal login.

## Related Issue(s)

Fixes #142 

## Type of Change

- [ ] Feature (new functionality)
- [x] Bug fix (fixes an issue)
- [ ] Documentation update
- [x] Code refactor
- [ ] Performance improvement
- [ ] Tests
- [ ] Infrastructure/build changes
- [ ] Other (please describe):

## Testing
**Manually:** Fresh DB → open app → /welcome → create admin → confirm redirect to /, authenticated UI, cookies present; refresh persists session; logout → /login with same credentials works.

**Edge case:** If POST /auth/register succeeds but handleLogin fails, confirm the error on /welcome and that the message is clear and short.

Screen recording of first-time admin registration: 

https://github.com/user-attachments/assets/6485c55d-df44-4010-b5cd-18b53417578a



## Checklist

### Before Requesting Review

- [x] I have tested my changes locally
- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards)
- [ ] I have added/updated necessary documentation
- [x] I have checked for and resolved any merge conflicts
- [x] I have linked this PR to relevant issue(s)

### Code Quality

- [ ] No debug `print` statements or `console.log` calls
- [ ] No `package-lock.json` (we use `yarn` only for the UI)
- [ ] No redundant or self-explanatory comments
- [ ] Error handling does not expose internal details to users

## Screenshots (if applicable)

## Additional Notes