### PR TITLE
fix (engine): remove stale_ensure_client() dead code from invoke()

### DIFF
--- a/engine/src/api/agent/graph.py
+++ b/engine/src/api/agent/graph.py
@@ -311,10 +311,6 @@ class WorkflowGraph:
     async def invoke(self, initial_state: Dict[str, Any], **kwargs):
         try:
             await self._ensure_compiled()
-            try:
-                await self.mcp_client._ensure_client()
-            except Exception:
-                pass
 
             start_time_value = get_state_value(initial_state, "start_time")
             if start_time_value is None:


### PR DESCRIPTION
# Description
Removes the stale `_ensure_client()` call and its surrounding try/except block 
from the `invoke()` method in `engine/src/api/agent/graph.py`. 
This method does not exist on the `MCPClient` class and the silent 
`except: pass` was swallowing the error, making it a maintenance hazard.

## Related Issue(s)
Fixes #77

## Type of Change
- [ ] Feature (new functionality)
- [x] Bug fix (fixes an issue)
- [ ] Documentation update
- [x] Code refactor
- [ ] Performance improvement
- [ ] Tests
- [ ] Infrastructure/build changes
- [ ] Other (please describe):

## Testing
Manually verified that removing the dead code block does not affect 
existing workflow execution. MCP tools continue to work as expected 
since _ensure_client() was never implemented and the error was being 
silently swallowed anyway.

## Checklist
### Before Requesting Review
- [x] I have tested my changes locally
- [x] My code follows the coding standards
- [x] I have added/updated necessary documentation
- [x] I have checked for and resolved any merge conflicts
- [x] I have linked this PR to relevant issue(s)

### Code Quality
- [x] No debug `print` statements or `console.log` calls
- [x] No `package-lock.json` (we use `yarn` only for the UI)
- [x] No redundant or self-explanatory comments
- [x] Error handling does not expose internal details to users

## Screenshots (if applicable)
N/A

## Additional Notes
Only 4 lines removed. No logic changes, no new code added.